### PR TITLE
Create basic builder pattern

### DIFF
--- a/crates/builder/Cargo.toml
+++ b/crates/builder/Cargo.toml
@@ -1,0 +1,7 @@
+[package]
+name = "rsdf_builder"
+version = "0.0.0"
+edition = "2021"
+
+[dependencies]
+rsdf_core = { path = "../core" }

--- a/crates/builder/Cargo.toml
+++ b/crates/builder/Cargo.toml
@@ -5,3 +5,8 @@ edition = "2021"
 
 [dependencies]
 rsdf_core = { path = "../core" }
+float-cmp = "0.9"
+
+[dev-dependencies]
+png = "0.17"
+itertools = "0.10"

--- a/crates/builder/examples/builder.rs
+++ b/crates/builder/examples/builder.rs
@@ -1,0 +1,126 @@
+use itertools::izip;
+use rsdf_builder::*;
+use rsdf_core::*;
+use std::env;
+use std::fs::File;
+
+fn main() {
+  let shape = ShapeBuilder::new()
+    .contour((10., 20.))
+    .line((60., 10.))
+    .line((50., 30.))
+    .quadratic_bezier((40., 50.), (20., 30.))
+    .line((10., 20.))
+    .end_contour()
+    .build();
+
+  let Some(filename) = env::args().nth(1) else { panic!("No output filename given") };
+  eprintln!("{filename:?}");
+  let input_filename = format!("{filename}.png");
+  let image = Image::new(&input_filename, [70, 70]);
+
+  gen(image, shape).flush();
+  view(&input_filename, &format!("{filename}_render.png"));
+}
+
+fn gen(mut image: Image, shape: Shape) -> Image {
+  let start_time = std::time::Instant::now();
+  for y in 0..image.height {
+    for x in 0..image.width {
+      let point = Point::from((x as f32, y as f32));
+      // let pixel = shape.sample_single_channel(point);
+      // let pixel = [pixel, pixel, pixel].map(|sp| distance_color(sp));
+      let pixel = shape.sample(point);
+      let pixel = pixel.map(|sp| distance_color(sp));
+      image.set_pixel([x, y], pixel);
+    }
+  }
+
+  let duration_time = std::time::Instant::now() - start_time;
+  dbg!(duration_time);
+
+  image
+}
+
+fn view(input_filename: &str, output_filename: &str) {
+  let decoder = png::Decoder::new(File::open(input_filename).unwrap());
+  let mut reader = decoder.read_info().unwrap();
+  let mut buf = vec![0; reader.output_buffer_size()];
+  let info = reader.next_frame(&mut buf).unwrap();
+
+  let bytes = &buf[..info.buffer_size()];
+
+  let sdf_width = info.width as usize;
+  let sdf_height = info.height as usize;
+
+  let mut image =
+    Image::new(&output_filename, [sdf_width * 10, sdf_height * 10]);
+
+  for y in 0..image.height {
+    for x in 0..image.width {
+      // normalised coordinates
+      let x_norm = x as f32 / (image.width) as f32;
+      let y_norm = y as f32 / (image.height) as f32;
+
+      // points in sdf coordinate system
+      let x_sdf_p = x_norm * (sdf_width - 1) as f32;
+      let y_sdf_p = y_norm * (sdf_height - 1) as f32;
+
+      // sample from points, bilinear
+      let pixel = {
+        let sample_sdf = |x, y| {
+          let offset = (y * sdf_width + x) * 3;
+          [bytes[offset], bytes[offset + 1], bytes[offset + 2]]
+        };
+
+        let x1 = (x_sdf_p - 0.5).floor();
+        let y1 = (y_sdf_p - 0.5).floor();
+        let x2 = x1 + 1.;
+        let y2 = y1 + 1.;
+        let wx = x_sdf_p - x1 - 0.5;
+        let wy = y_sdf_p - y1 - 0.5;
+
+        let t1 = sample_sdf(x1 as usize, y1 as usize)
+          .map(|v| (1. - wx) * (1. - wy) * v as f32);
+        let t2 = sample_sdf(x2 as usize, y1 as usize)
+          .map(|v| wx * (1. - wy) * v as f32);
+        let t3 = sample_sdf(x1 as usize, y2 as usize)
+          .map(|v| (1. - wx) * wy * v as f32);
+        let t4 =
+          sample_sdf(x2 as usize, y2 as usize).map(|v| wx * wy * v as f32);
+
+        let result: Vec<f32> = izip!(t1, t2, t3, t4)
+          .map(|(v1, v2, v3, v4)| v1 + v2 + v3 + v4)
+          .collect();
+
+        [result[0] as u8, result[1] as u8, result[2] as u8]
+      };
+
+      // find the median value
+      let median = |a, b, c| {
+        if (a <= b && b <= c) || (c <= b && b <= a) {
+          b
+        } else if (a <= c && c <= b) || (b <= c && c <= a) {
+          c
+        } else {
+          a
+        }
+      };
+      let value = median(pixel[0], pixel[1], pixel[2]);
+
+      // colour the output based on a simple threshold
+      let mut output = 0;
+      if value > 120 {
+        output = 255;
+      }
+      // add a red outline effect
+      let mut r_output = output;
+      if value > 117 {
+        r_output = 255;
+      }
+
+      image.set_pixel([x, y], [r_output, output, output]);
+    }
+  }
+  image.flush();
+}

--- a/crates/builder/src/lib.rs
+++ b/crates/builder/src/lib.rs
@@ -1,0 +1,3 @@
+use rsdf_core::*;
+
+// TODO: create Shape builder pattern

--- a/crates/builder/src/lib.rs
+++ b/crates/builder/src/lib.rs
@@ -1,3 +1,168 @@
+#![allow(clippy::new_without_default)]
+
 use rsdf_core::*;
 
-// TODO: create Shape builder pattern
+pub struct ShapeBuilder {
+  shape: Shape,
+}
+
+impl ShapeBuilder {
+  pub fn new() -> Self {
+    Self {
+      shape: Shape {
+        points: vec![],
+        segments: vec![],
+        splines: vec![],
+        contours: vec![],
+      },
+    }
+  }
+
+  pub fn build(self) -> Shape {
+    self.shape
+  }
+
+  pub fn contour(self, start_point: impl Into<Point>) -> ContourBuilder {
+    ContourBuilder::new(self.shape, start_point)
+  }
+}
+
+pub struct ContourBuilder {
+  shape: Shape,
+  current_spline: Spline,
+}
+
+impl ContourBuilder {
+  fn new(mut shape: Shape, start_point: impl Into<Point>) -> Self {
+    shape.points.push(start_point.into());
+    let spline_len = shape.splines.len();
+    shape.contours.push(Contour {
+      spline_range: spline_len..spline_len,
+    });
+
+    let segments_len = shape.segments.len();
+    ContourBuilder {
+      shape,
+      current_spline: Spline {
+        segments_range: segments_len..segments_len,
+        colour: Colour::Magenta,
+      },
+    }
+  }
+
+  pub fn line(mut self, end_point: impl Into<Point>) -> Self {
+    self.shape.points.push(end_point.into());
+    self.shape.segments.push(SegmentRef {
+      kind: SegmentKind::Line,
+      points_index: self.shape.points.len() - 2,
+    });
+    self.check_for_and_create_new_spline();
+    self
+  }
+
+  pub fn quadratic_bezier(
+    mut self,
+    control_point: impl Into<Point>,
+    end_point: impl Into<Point>,
+  ) -> Self {
+    self.shape.points.push(control_point.into());
+    self.shape.points.push(end_point.into());
+    self.shape.segments.push(SegmentRef {
+      kind: SegmentKind::QuadBezier,
+      points_index: self.shape.points.len() - 3,
+    });
+    self.check_for_and_create_new_spline();
+    self
+  }
+
+  pub fn cubic_bezier(
+    mut self,
+    control_point_1: impl Into<Point>,
+    control_point_2: impl Into<Point>,
+    end_point: impl Into<Point>,
+  ) -> Self {
+    self.shape.points.push(control_point_1.into());
+    self.shape.points.push(control_point_2.into());
+    self.shape.points.push(end_point.into());
+    self.shape.segments.push(SegmentRef {
+      kind: SegmentKind::CubicBezier,
+      points_index: self.shape.points.len() - 4,
+    });
+    self.check_for_and_create_new_spline();
+    self
+  }
+
+  pub fn end_contour(mut self) -> ShapeBuilder {
+    // finish spline
+    self.current_spline.segments_range.end = self.shape.segments.len();
+    self.shape.splines.push(self.current_spline.clone());
+    let (first_point, last_point) = {
+      // TODO: ensure contour is closed
+      let first_spline_i =
+        self.shape.contours.last().unwrap().spline_range.start;
+      let first_segment_i =
+        self.shape.splines[first_spline_i].segments_range.start;
+      let first_segment = self.shape.segments[first_segment_i];
+      let first_point = self.shape.get_segment(first_segment).sample(0f32);
+      let segments_len = self.shape.segments.len();
+      let last_segment = self.shape.segments[segments_len - 1];
+      let last_point = self.shape.get_segment(last_segment).sample(1f32);
+      (first_point, last_point)
+    };
+    let mut shape = if !float_cmp::approx_eq!(Point, first_point, last_point) {
+      self.line(first_point).shape
+    } else {
+      self.shape
+    };
+
+    // check to see if the first & last spline are continuous
+    // if !self.is_sharp_corner(segments_len - 1, first_segment_i) {
+    // todo!() // adjust colour of spline as appropriate
+    // }
+
+    let contour = shape.contours.last_mut().unwrap();
+    contour.spline_range.end = shape.splines.len();
+
+    ShapeBuilder { shape }
+  }
+
+  fn is_sharp_corner(
+    &self,
+    segment_index_a: usize,
+    segment_index_b: usize,
+  ) -> bool {
+    let segment_a = self.shape.segments[segment_index_a];
+    let segment_b = self.shape.segments[segment_index_b];
+    let d1 = self
+      .shape
+      .get_segment(segment_a)
+      .sample_derivative(1.0)
+      .norm();
+    let d2 = self
+      .shape
+      .get_segment(segment_b)
+      .sample_derivative(0.0)
+      .norm();
+    !float_cmp::approx_eq!(Vector, d1, d2)
+  }
+
+  fn check_for_and_create_new_spline(&mut self) {
+    let segments_len = self.shape.segments.len();
+    // check we even have more than one segment in this spline yet
+    if segments_len > self.current_spline.segments_range.start + 1
+      && self.is_sharp_corner(segments_len - 2, segments_len - 1)
+    {
+      // finish old spline
+      self.current_spline.segments_range.end = segments_len - 1;
+      self.shape.splines.push(self.current_spline.clone());
+      // create new spline
+      self.current_spline.segments_range = segments_len - 1..segments_len;
+      self.current_spline.colour =
+        if self.current_spline.colour == Colour::Magenta {
+          Colour::Yellow
+        } else {
+          self.current_spline.colour ^ Colour::Magenta
+        }
+    }
+  }
+}

--- a/crates/core/src/math/point.rs
+++ b/crates/core/src/math/point.rs
@@ -67,7 +67,6 @@ impl std::ops::Sub<Vector> for Point {
   }
 }
 
-#[cfg(any(test, doc_test))]
 impl float_cmp::ApproxEq for Point {
   type Margin = float_cmp::F32Margin;
 

--- a/crates/core/src/math/vector.rs
+++ b/crates/core/src/math/vector.rs
@@ -168,7 +168,6 @@ impl std::ops::Sub<Point> for Vector {
   }
 }
 
-#[cfg(any(test, doc_test))]
 impl float_cmp::ApproxEq for Vector {
   type Margin = float_cmp::F32Margin;
 

--- a/crates/core/src/shape/sample.rs
+++ b/crates/core/src/shape/sample.rs
@@ -1,40 +1,50 @@
 use crate::*;
+use std::f32::{INFINITY, NEG_INFINITY};
 
 /// Threshold for float comparisons
 const EPSILON: f32 = 0.0001;
 
+type Dist = (/* distance */ f32, /* orthogonality */ f32);
+
 impl Shape {
   /// Sample the signed distance of the shape at the given [`Point`]
-  #[rustfmt::skip]
+
   pub fn sample_single_channel(&self, point: Point) -> f32 {
-    let mut selected_dist = (f32::INFINITY, f32::NEG_INFINITY);
-    for contour in self.contours.iter().cloned() {
-      for Spline { segments_range, colour: _ }
-        in self.splines[contour.spline_range].iter().cloned()
+    let mut selected_dist: Dist = (INFINITY, NEG_INFINITY);
+
+    for contour in self.contours.iter() {
+      for Spline {
+        segments_range,
+        colour: _,
+      } in self.splines[contour.spline_range.clone()].iter()
       {
-        let dist = self.spline_distance_orthogonality(segments_range, point);
+        let dist =
+          self.spline_distance_orthogonality(segments_range.clone(), point);
         if closer(dist, selected_dist) {
           selected_dist = dist;
         }
       }
     }
+
     selected_dist.0
   }
 
   /// Sample the multi-channel signed pseudo distance of the shape at the given
   /// [`Point`]
-  #[rustfmt::skip]
   pub fn sample(&self, point: Point) -> [f32; 3] {
     let [mut red_spline, mut green_spline, mut blue_spline] =
       [None, None, None];
-    let [mut red_dist, mut green_dist, mut blue_dist] =
-      [(f32::INFINITY, f32::NEG_INFINITY); 3];
+    let [mut red_dist, mut green_dist, mut blue_dist]: [Dist; 3] =
+      [(INFINITY, NEG_INFINITY); 3];
 
-    for Contour { spline_range } in self.contours.iter().cloned() {
-      for Spline { segments_range, colour }
-        in self.splines[spline_range].iter().cloned()
+    for Contour { spline_range } in self.contours.iter() {
+      for Spline {
+        segments_range,
+        colour,
+      } in self.splines[spline_range.clone()].iter().cloned()
       {
-        let dist = self.spline_distance_orthogonality(segments_range.clone(), point);
+        let dist =
+          self.spline_distance_orthogonality(segments_range.clone(), point);
 
         if (colour & Red == Red) && closer(dist, red_dist) {
           red_dist = dist;
@@ -48,13 +58,13 @@ impl Shape {
 
         if (colour & Blue == Blue) && closer(dist, blue_dist) {
           blue_dist = dist;
-          blue_spline = Some(segments_range);
+          blue_spline = Some(segments_range.clone());
         }
       }
     }
 
     [red_spline, green_spline, blue_spline].map(|r| {
-      r.map_or(f32::NEG_INFINITY, |spline| {
+      r.map_or(NEG_INFINITY, |spline| {
         self.spline_pseudo_distance(spline, point)
       })
     })
@@ -63,8 +73,8 @@ impl Shape {
 
 /// Comparison function for pairs of distances
 fn closer(
-  (distance_a, orthogonality_a): (f32, f32),
-  (distance_b, orthogonality_b): (f32, f32),
+  (distance_a, orthogonality_a): Dist,
+  (distance_b, orthogonality_b): Dist,
 ) -> bool {
   distance_b.abs() - distance_a.abs() > EPSILON
     || (orthogonality_a.abs() > orthogonality_b.abs()


### PR DESCRIPTION
Programmatically creating shapes is probably useful, at the very least for testing. 

This provides a basic sane API to do that, without having to manually manage all the junk inside a `Shape`.